### PR TITLE
Update readme to include libopus with ffmpeg

### DIFF
--- a/cmd/dca/README.md
+++ b/cmd/dca/README.md
@@ -67,7 +67,8 @@ Provided by Uniquoooo
 This way uses Homebrew, download it from [here.](http://brew.sh/)
 
 ```
-$ brew install ffmpeg golang
+$ brew install ffmpeg --with-opus
+$ brew install golang
 $ go get github.com/jonas747/dca/cmd/dca
 ```
 


### PR DESCRIPTION
Regularly installing ffmpeg without the --with-opus flag in homebrew will cause dca to start ffmpeg with an invalid flag. Installing ffmpeg with the flag resolves this issue.