### PR TITLE
Moved ffmpeg reconnect options to before the input file in order for them to take effect.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -202,11 +202,11 @@ func (e *EncodeSession) run() {
 	// Launch ffmpeg with a variety of different fruits and goodies mixed togheter
 	args := []string{
 		"-stats",
-		"-i", inFile,
 		"-reconnect", "1",
 		"-reconnect_at_eof", "1",
 		"-reconnect_streamed", "1",
 		"-reconnect_delay_max", "2",
+		"-i", inFile,
 		"-map", "0:a",
 		"-acodec", "libopus",
 		"-f", "ogg",


### PR DESCRIPTION
This should fix the reconnect problems that issue #12 was experiencing.

Issue #15 modified the reconnect optins incorrectly, because the options were after the stream input, they did not affect it so ffmpeg does not perform any reconnects if there is an error in the stream. 

There is no concree documentation stating the reconnect options should be out before the input file but examples with the options before th input file can be found: 
- https://stackoverflow.com/questions/62713627/ffmpeg-gives-pull-error-in-the-middle-of-song-discord-py
- https://stackoverflow.com/questions/43218292/youtubedl-read-error-with-discord-py

Thanks