### PR TITLE
Avoid timeout memory leak

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -100,14 +100,15 @@ func (s *StreamingSession) readNext() error {
 	}
 
 	// Timeout after 100ms (Maybe this needs to be changed?)
-	timeOut := time.After(time.Second)
+	timeOut := time.NewTimer(time.Second)
 
 	// This will attempt to send on the channel before the timeout, which is 1s
 	select {
-	case <-timeOut:
+	case <-timeOut.C:
 		return ErrVoiceConnClosed
 	case s.vc.OpusSend <- opus:
 	}
+	timeOut.Stop()
 
 	s.Lock()
 	s.framesSent++

--- a/stream.go
+++ b/stream.go
@@ -107,8 +107,8 @@ func (s *StreamingSession) readNext() error {
 	case <-timeOut.C:
 		return ErrVoiceConnClosed
 	case s.vc.OpusSend <- opus:
+		timeOut.Stop()
 	}
-	timeOut.Stop()
 
 	s.Lock()
 	s.framesSent++


### PR DESCRIPTION
Hello
From [time.After](https://pkg.go.dev/time#After) doc:

> The underlying Timer is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed.

So in this pull request, I just used [NewTimer](https://pkg.go.dev/time#NewTimer) and [Stop](https://pkg.go.dev/time#Timer.Stop) to avoid these small memory leaks. Note that the underlaying memory will be collected after one second at last even if you use time.After but I think It's better to free the memory as soon as possible.