### PR TITLE
Update OS X installation readme

### DIFF
--- a/cmd/dca/README.md
+++ b/cmd/dca/README.md
@@ -64,12 +64,12 @@ dca should now be built in %GOPATH%/bin
 
 Provided by Uniquoooo
 
-This way uses Homebrew, download it from [here.](http://brew.sh/)
+This way uses Homebrew, download it from [here.](https://brew.sh/)
 
-```
-$ brew install ffmpeg --with-opus
-$ brew install golang
-$ go get github.com/jonas747/dca/cmd/dca
+```bash
+brew install ffmpeg
+brew install golang
+go install github.com/jonas747/dca/cmd/dca@latest
 ```
 
 


### PR DESCRIPTION
Nowadays, we get the following errors:

* Error: invalid option: --with-opus
* 'go get' is no longer supported outside a module.
  To build and install a command, use 'go install' with a version,
  like 'go install example.com/cmd@latest'